### PR TITLE
 Added support for Access 2007 and earlier

### DIFF
--- a/MSAccess-VCS/VCS_DataMacro.bas
+++ b/MSAccess-VCS/VCS_DataMacro.bas
@@ -3,6 +3,10 @@ Option Compare Database
 
 Option Explicit
 
+' For Access 2007 (VBA6) and earlier
+#If Not VBA7 Then
+  Const acTableDataMacro = 12
+#End If
 
 Public Sub ExportDataMacros(tableName As String, directory As String)
     On Error GoTo Err_export:

--- a/MSAccess-VCS/VCS_File.bas
+++ b/MSAccess-VCS/VCS_File.bas
@@ -3,16 +3,29 @@ Option Compare Database
 
 Option Explicit
 
-Private Declare PtrSafe _
-    Function getTempPath Lib "kernel32" _
-         Alias "GetTempPathA" (ByVal nBufferLength As Long, _
-                               ByVal lpBuffer As String) As Long
-Private Declare PtrSafe _
-    Function getTempFileName Lib "kernel32" _
-         Alias "GetTempFileNameA" (ByVal lpszPath As String, _
-                                   ByVal lpPrefixString As String, _
-                                   ByVal wUnique As Long, _
-                                   ByVal lpTempFileName As String) As Long
+#If VBA7 Then
+  Private Declare PtrSafe _
+      Function getTempPath Lib "kernel32" _
+           Alias "GetTempPathA" (ByVal nBufferLength As Long, _
+                                 ByVal lpBuffer As String) As Long
+  Private Declare PtrSafe _
+      Function getTempFileName Lib "kernel32" _
+           Alias "GetTempFileNameA" (ByVal lpszPath As String, _
+                                     ByVal lpPrefixString As String, _
+                                     ByVal wUnique As Long, _
+                                     ByVal lpTempFileName As String) As Long
+#Else
+  Private Declare _
+      Function getTempPath Lib "kernel32" _
+           Alias "GetTempPathA" (ByVal nBufferLength As Long, _
+                                 ByVal lpBuffer As String) As Long
+  Private Declare _
+      Function getTempFileName Lib "kernel32" _
+           Alias "GetTempFileNameA" (ByVal lpszPath As String, _
+                                     ByVal lpPrefixString As String, _
+                                     ByVal wUnique As Long, _
+                                     ByVal lpTempFileName As String) As Long
+#End If
 
 ' --------------------------------
 ' Structures
@@ -182,7 +195,7 @@ End Sub
 Public Function UsingUcs2() As Boolean
     Dim obj_name As String, i As Integer, obj_type As Variant, fn As Integer, bytes As String
     Dim obj_type_split() As String, obj_type_name As String, obj_type_num As Integer
-    Dim db As Object ' DAO.Database
+    Dim Db As Object ' DAO.Database
 
     If CurrentDb.QueryDefs.Count > 0 Then
         obj_type_num = acQuery
@@ -242,4 +255,5 @@ Dim sFileName As String
     If nRet <> 0 Then sFileName = Left$(sTmpName, InStr(sTmpName, vbNullChar) - 1)
     TempFile = sFileName
 End Function
+
 


### PR DESCRIPTION
The Declare statements use the PtrSafe keyword which doesn't exist
in Access 2007. So, they need to be wrapped in a if-else that checks
the version of VBE.
See: https://msdn.microsoft.com/en-us/library/office/gg278832.aspx

The enumeration value  is a new member of .
Data macros are a new feature of Access 2010.
See: https://support.office.com/en-us/article/Create-a-data-macro-b1b94bca-4f17-47ad-a66d-f296ef834200
